### PR TITLE
Update syntax to highlight tags

### DIFF
--- a/gclient/syntaxes/feature.tmLanguage
+++ b/gclient/syntaxes/feature.tmLanguage
@@ -202,7 +202,7 @@
         <key>0</key>
         <dict>
           <key>name</key>
-          <string>storage.type.tag.cucumber</string>
+          <string>entity.name.type.class.tsx</string>
         </dict>
       </dict>
       <key>match</key>


### PR DESCRIPTION
Currently the tags don't stand out very much:

![current.png](http://i.imgur.com/lGu6EUd.png)

This is what I am proposing:

![proposed.png](http://i.imgur.com/OepUGQ8.png)

I'm not sure which scope this should use, so I used the `entity.name.type.class.tsx` one.