### PR TITLE
Fix spelling: cucucumber to cucumber.

### DIFF
--- a/gclient/README.md
+++ b/gclient/README.md
@@ -64,7 +64,7 @@ VSCode Cucumber (Gherkin) Language Support + Format + Steps/PageObjects Autocomp
         "main": "test/features/support/page_objects/main.page.js"
     },
     "cucumberautocomplete.skipDocStringsFormat": true,
-    "cucucumberautocomplete.formatConfOverride": {
+    "cucumberautocomplete.formatConfOverride": {
         "And": 3,
         "But": "relative",
     },

--- a/gclient/package.json
+++ b/gclient/package.json
@@ -102,13 +102,13 @@
                     "required": false,
                     "default": []
                 },
-                "cucucumberautocomplete.skipDocStringsFormat": {
+                "cucumberautocomplete.skipDocStringsFormat": {
                     "description": "Skip format of strings, that placed between ''' or \"\"\" strings",
                     "type": "boolean",
                     "required": false,
                     "default": false
                 },
-                "cucucumberautocomplete.formatConfOverride": {
+                "cucumberautocomplete.formatConfOverride": {
                     "description": "Override some formatting via format conf strings = {[key: String]: num | 'relative'}, where key - beggining of the string, num - numeric value of indents",
                     "type": "object",
                     "required": false,


### PR DESCRIPTION
Both the README and the package.json have incorrect text for the preference for formatConfOverride, and using the name specified there doesn't work.

This patch corrects that, and also the one for skipDocStringsFormat.