### PR TITLE
Allow setting to zero values which default to non-zero.

### DIFF
--- a/gserver/src/format.ts
+++ b/gserver/src/format.ts
@@ -32,7 +32,7 @@ function findFormat(line: string, settings: Settings): FormatConfVal | null {
     };
     const settingsFormat = fnFormatFinder(settingsFormatConf);
     const pesetFormat = fnFormatFinder(FORMAT_CONF);
-    return settingsFormat || pesetFormat;
+    return (settingsFormat === null) ? pesetFormat : settingsFormat;
 }
 
 export function clearText(text: string) {

--- a/gserver/test/data/after.format.feature
+++ b/gserver/test/data/after.format.feature
@@ -35,7 +35,7 @@ Feature: Formatting feature
 			But not an invalid result
 
 
-	Scenario Outline: feeding a suckler cow
+Scenario Outline: feeding a suckler cow
 
 		Given the cow weighs <weight> kg
 		When we calculate the feeding requirements

--- a/gserver/test/format.spec.ts
+++ b/gserver/test/format.spec.ts
@@ -9,6 +9,7 @@ const settings: any = {
             'But': 3,
             'And': 'asdasd',
             'SomeTestKey': 12,
+            'Scenario Outline': 0,
         }
     }
 };


### PR DESCRIPTION
This is a bugfix. Values which defaulted to non-zero values (everything except Feature) could not be overridden to be set to zero due to the method of comparison using ||. The change is to explicitly check for null instead.

One test has been added to verify this behaviour.