### PR TITLE
Step documentation in intellisense popup

### DIFF
--- a/gserver/package.json
+++ b/gserver/package.json
@@ -10,7 +10,8 @@
     "glob": "^7.1.1",
     "md5": "^2.2.1",
     "strip-comments": "^0.4.4",
-    "vscode-languageserver": "^3.5.0"
+    "vscode-languageserver": "^3.5.0",
+    "doctrine": "^2.1.0"
   },
   "devDependencies": {
     "@types/chai": "^3.4.34",

--- a/gserver/src/steps.handler.ts
+++ b/gserver/src/steps.handler.ts
@@ -137,7 +137,7 @@ export default class StepsHandler {
     }
 
     getPositionFromMatchIndex(matchIndex: number, fileContent: string): {line: number, chr: number} {
-        let line = 0;
+        let line = -1;
         let lastLineIndex = 0;
         let chr = 0;
         let match;
@@ -367,7 +367,8 @@ export default class StepsHandler {
             const stepParsedComment = commentParser.parse(stepRawComment.trim(), {unwrap: true, sloppy: true, recoverable: true});
 
             if (clearComments(rawMatch + '*/').match(stepCommentValidator)) {
-                const stepPosition = this.getPositionFromMatchIndex(rawStepMatch.index, definitionFile);
+
+                const stepPosition = this.getPositionFromMatchIndex(rawStepMatch.index + rawMatch.indexOf(stepBody), definitionFile);
 
                 const pos = Position.create(stepPosition.line, stepPosition.chr);
                 const def = Location.create(getOSPath(filePath), Range.create(pos, pos));

--- a/gserver/test/data/test.documentation.js
+++ b/gserver/test/data/test.documentation.js
@@ -1,0 +1,35 @@
+this.When(/I write named functions/, function namedFunction(next) {
+    next;
+});
+
+this.When(/I write named async functions/, async function namedAsyncFunction(next) {
+    next;
+});
+
+/**
+ * unstructured description
+ */
+this.When(/I write documented functions with unstructured description/, function (next) {
+    next;
+});
+
+/**
+ * @description structured description
+ */
+this.When(/I write documented functions with structured description/, function (next) {
+    next;
+});
+
+/**
+ * @desc structured name
+ */
+this.When(/I write documented functions with structured desc/, function (next) {
+    next;
+});
+
+/**
+ * Overriding description
+ */
+this.When(/I write documented named functions/, function nameToOverride(next) {
+    next;
+});

--- a/gserver/test/steps.handler.spec.ts
+++ b/gserver/test/steps.handler.spec.ts
@@ -229,6 +229,24 @@ describe('validateConfiguration', () => {
     });
 });
 
+describe('Documentation parser', () => {
+    const sDocumentation = new StepsHandler(__dirname, {
+        cucumberautocomplete: {steps: ['/data/test.documentation*.js']}
+    });
+
+    it('should extract function name when available', () => {
+        expect(sDocumentation.elements.some(step => step.documentation === 'namedFunction')).to.be.true;
+        expect(sDocumentation.elements.some(step => step.documentation === 'namedAsyncFunction')).to.be.true;
+    });
+
+    it('should extract JSDOC properties when available', () => {
+        expect(sDocumentation.elements.some(step => step.documentation === 'unstructured description')).to.be.true;
+        expect(sDocumentation.elements.some(step => step.documentation === 'structured description')).to.be.true;
+        expect(sDocumentation.elements.some(step => step.documentation === 'structured name')).to.be.true;
+        expect(sDocumentation.elements.some(step => step.documentation === 'Overriding description')).to.be.true;
+    });
+});
+
 describe('validate', () => {
     it('should not return diagnostic for correct lines', () => {
         expect(s.validate('When I do something', 1, '')).to.be.null;


### PR DESCRIPTION
This pull request allows the cucumber automation engineer to provide human-readable documentation for the spec-writing user.
This can be done by:

- Writing named functions - The function name will be shown.
- Documenting the steps - The structured / unstructured documentation will be shown.

--- 
In order to achieve this, the step harvesting mechanism was rebuilt around regexp iterative processing. This enabled capturing the relevant comment blocks and function name.

Currently the returned step documentation is simply the function name / unstructured commend / structured comment `@description` field. However, this solution can facilitate further improvements:

- Returning the entire JSDOC as markdown
- Matching JSDOC `@param` fields with regexp capture groups, and providing relevant parameter documentation when applicable
- Extending the regexp capture and parsing to more syntaxes
- Providing the user with customizable JSDOC parsing via the extension settings (e.g. work with different JSDOC fields)