### PR TITLE
Add homepage and other links for extension

### DIFF
--- a/gclient/package.json
+++ b/gclient/package.json
@@ -8,6 +8,14 @@
     "license": "MIT",
     "displayName": "Cucumber (Gherkin) Full Support",
     "description": "VSCode Cucumber (Gherkin) Full Language Support + Formatting + Autocomplete",
+    "homepage": "https://github.com/alexkrechik/VSCucumberAutoComplete",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/alexkrechik/VSCucumberAutoComplete"
+    },
+    "bugs": {
+        "url": "https://github.com/alexkrechik/VSCucumberAutoComplete/issues"
+    },
     "categories": [
         "Programming Languages"
     ],


### PR DESCRIPTION
Simple tiny PR.
Was looking at submitting some PRs for this great extension and couldn't find the GitHub repo.
Had to look at the `package.json` in extensions folder.
This will ensure the necessary information is displayed on the marketplace.
Right now the repo url, home page, link to add issues are not on the marketplace.

I wanted to submit PRs, but there could be those who wish to report issues