### PR TITLE
Allows formatting of <spaced variables>

### DIFF
--- a/gclient/syntaxes/feature.tmLanguage
+++ b/gclient/syntaxes/feature.tmLanguage
@@ -144,7 +144,7 @@
     <key>scenario_outline_variable</key>
     <dict>
       <key>match</key>
-      <string>&lt;[a-zA-Z0-9_-]*&gt;</string>
+      <string>&lt;[a-zA-Z0-9 _-]*&gt;</string>
       <key>name</key>
       <string>variable.other</string>
     </dict>


### PR DESCRIPTION
Currently a space in a variable will break the formatting

```feature
Scenario Outline: Test
        Given <great formatting>
```
        
Will display the <great formatting> in white instead of in blue. 

This functionality may have been broken as part of https://github.com/alexkrechik/VSCucumberAutoComplete/issues/127