### PR TITLE
feat(syntax): use embedded language for json

### DIFF
--- a/gclient/package.json
+++ b/gclient/package.json
@@ -55,6 +55,16 @@
                 "language": "feature",
                 "scopeName": "text.gherkin.feature",
                 "path": "./syntaxes/feature.tmLanguage"
+            },
+            {
+                "injectTo": [
+                    "text.gherkin.feature"
+                ],
+                "scopeName": "text.gherkin.feature.json",
+                "path": "./syntaxes/json-embed.json",
+                "embeddedLanguages": {
+                    "meta.embedded.block.json": "json"
+                }
             }
         ],
         "snippets": [

--- a/gclient/syntaxes/json-embed.json
+++ b/gclient/syntaxes/json-embed.json
@@ -1,0 +1,27 @@
+{
+  "fileTypes": ["feature"],
+  "scopeName": "text.gherkin.feature.json",
+  "injectionSelector": "L:text -comment",
+  "patterns": [
+    {
+      "contentName": "meta.embedded.block.json",
+      "begin": "(json|JSON)\\s*$",
+      "end": "(?<=\"\"\")",
+      "patterns": [
+        {
+          "begin": "^\\s*(\"\"\")$",
+          "beginCaptures": {
+            "1": { "name": "string.quoted.double.start" }
+          },
+          "end": "^\\s*(\"\"\")",
+          "endCaptures": {
+            "1": { "name": "string.quoted.double.end" }
+          },
+          "patterns": [
+            { "include": "source.json" }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The steps line should end with the word "json" or "JSON" to let vscode recognize the emedded language as JSON.

Make this:
![image](https://user-images.githubusercontent.com/760112/59028081-4a914c00-8878-11e9-838f-6ed192621f12.png)

into this:
![image](https://user-images.githubusercontent.com/760112/59028070-436a3e00-8878-11e9-83e7-b6772d25407b.png)
