### PR TITLE
fix: tables formatting with CJK characters

### DIFF
--- a/gserver/src/format.ts
+++ b/gserver/src/format.ts
@@ -150,9 +150,9 @@ function formatTables(text) {
 
 // Consider a CJK character is 2 spaces
 function stringBytesLen(c) {
-    var n = c.length, s;
-    var len = 0;
-    for (var i = 0; i < n; i++) {
+    let n = c.length, s;
+    let len = 0;
+    for (let i = 0; i < n; i++) {
         s = c.charCodeAt(i);
         while (s > 0) {
             len++;

--- a/gserver/src/format.ts
+++ b/gserver/src/format.ts
@@ -129,9 +129,9 @@ function formatTables(text) {
     const maxes = blocks.reduce((res, b) => {
         const block = b.block;
         if (res[block]) {
-            res[block] = res[block].map((v, i) => Math.max(v, b.data[i].length));
+            res[block] = res[block].map((v, i) => Math.max(v, stringBytesLen(b.data[i])));
         } else {
-            res[block] = b.data.map(v => v.length);
+            res[block] = b.data.map(v => stringBytesLen(v));
         }
         return res;
     }, []);
@@ -139,13 +139,27 @@ function formatTables(text) {
     //Change all the 'block' lines in our document using correct distance between words
     blocks.forEach(block => {
         let change = block.data
-            .map((d, i) => ` ${d}${' '.repeat(maxes[block.block][i] - d.length)} `)
+            .map((d, i) => ` ${d}${' '.repeat(maxes[block.block][i] - stringBytesLen(d))} `)
             .join('|');
         change = `|${change}|`;
         textArr[block.line] = textArr[block.line].replace(/\|.*/, change);
     });
 
     return textArr.join('\r\n');
+}
+
+// Consider a CJK character is 2 spaces
+function stringBytesLen(c) {
+    var n = c.length, s;
+    var len = 0;
+    for (var i = 0; i < n; i++) {
+        s = c.charCodeAt(i);
+        while (s > 0) {
+            len++;
+            s = s >> 8;
+        }
+    }
+    return len;
 }
 
 export function format(indent: string, text: string, settings: Settings): string {

--- a/gserver/test/data/features/after.format.feature
+++ b/gserver/test/data/features/after.format.feature
@@ -7,10 +7,10 @@ Feature: Formatting feature
 	Background: Background name
 
 		Given the following users exist:
-			| name   | email              | twitter         |
-			| Aslak  | aslak@cucumber.io  | @aslak_hellesoy |
-			| Julien | julien@cucumber.io | @jbpros         |
-			| Matt   | matt@cucumber.io   | @mattwynne      |
+			| name   | email              | twitter         | CJK Message 訊息    |
+			| Aslak  | aslak@cucumber.io  | @aslak_hellesoy | Yoo Hello world     |
+			| Julien | julien@cucumber.io | @jbpros         | Yoo 你好 世界       |
+			| Matt   | matt@cucumber.io   | @mattwynne      | Yoo こんにちは 世界 |
 
 
 	#This comment is related to this Scenario:

--- a/gserver/test/data/features/before.format.feature
+++ b/gserver/test/data/features/before.format.feature
@@ -7,14 +7,14 @@ This feature was created to test formatting
 Background: Background name
 
 Given the following users exist:
-| name |email| twitter|
-| Aslak|    aslak@cucumber.io | @aslak_hellesoy |
-| Julien|julien@cucumber.io| @jbpros|
-| Matt|matt@cucumber.io| @mattwynne|
+| name |email| twitter| CJK Message 訊息 |
+| Aslak|    aslak@cucumber.io | @aslak_hellesoy | Yoo Hello world |
+| Julien|julien@cucumber.io| @jbpros| Yoo 你好 世界 |
+| Matt|matt@cucumber.io| @mattwynne| Yoo こんにちは 世界 |
 
 
 #This comment is related to this Scenario:
-Scenario: Some scenario     
+Scenario: Some scenario
 
 #Comment related to the next string
 Given I prepare for something
@@ -40,7 +40,7 @@ Scenario: Should properly format star gherkin word
 * I do something
 
 
-Scenario Outline: feeding a suckler cow      
+Scenario Outline: feeding a suckler cow
 
 Given the cow weighs <weight> kg
 When we calculate the feeding requirements


### PR DESCRIPTION
Table formatting is painful for CJK character users :(

Treat a CJK character with 2 spaces.

You'll need to install CJK fonts to get it work on your machine

![img](https://i.imgur.com/JrPLQ8x.png)