### PR TITLE
fix: format json with scenario example <tags>

### DIFF
--- a/gserver/src/format.ts
+++ b/gserver/src/format.ts
@@ -164,13 +164,12 @@ function formatJson(textBody: string, indent: string) {
         let taggedMap = {}
         let taggedTexts;
         while ((taggedTexts = /<.*?>/g.exec(preJson)) !== null) {
-            console.log(taggedTexts)
-            for (let i in taggedTexts) {
+            taggedTexts.forEach(function (tag, index) {
                 let uuid = createUUID()
 
-                taggedMap[uuid] = taggedTexts[i]
-                preJson = preJson.replace(taggedTexts[i], uuid)
-            }
+                taggedMap[uuid] = tag
+                preJson = preJson.replace(tag, uuid)
+            })
         }
         if (!isJson(preJson)) {
             continue

--- a/gserver/src/format.ts
+++ b/gserver/src/format.ts
@@ -161,6 +161,17 @@ function formatJson(textBody: string, indent: string) {
 
     for (let txt of textArr) {
         let preJson = txt.replace(rxQuoteBegin, '')
+        let taggedMap = {}
+        let taggedTexts;
+        while ((taggedTexts = /<.*?>/g.exec(preJson)) !== null) {
+            console.log(taggedTexts)
+            for (let i in taggedTexts) {
+                let uuid = createUUID()
+
+                taggedMap[uuid] = taggedTexts[i]
+                preJson = preJson.replace(taggedTexts[i], uuid)
+            }
+        }
         if (!isJson(preJson)) {
             continue
         }
@@ -173,6 +184,12 @@ function formatJson(textBody: string, indent: string) {
         jsonTxt = '\n"""\n' + jsonTxt + '\n"""'
         jsonTxt = jsonTxt.replace(/^/gm, textIndent)
 
+        // Restore tagged json
+        for (let uuid in taggedMap) {
+            if (taggedMap.hasOwnProperty(uuid)) {
+                jsonTxt = jsonTxt.replace(uuid, taggedMap[uuid])
+            }
+        }
         textBody = textBody.replace(txt, jsonTxt)
     }
     return textBody;
@@ -185,6 +202,10 @@ function isJson(str) {
         return false;
     }
     return true;
+}
+
+function createUUID() {
+    return (Math.floor(Math.random() * 1000000000)).toString()
 }
 
 // Consider a CJK character is 2 spaces

--- a/gserver/test/data/features/after.format.feature
+++ b/gserver/test/data/features/after.format.feature
@@ -38,7 +38,7 @@ Feature: Formatting feature
 			"""
 			[
 				{
-					"json": <text>
+					"<json>": <text>
 				}
 			]
 			"""

--- a/gserver/test/data/features/after.format.feature
+++ b/gserver/test/data/features/after.format.feature
@@ -34,6 +34,15 @@ Feature: Formatting feature
 			]
 			"""
 
+			And here is the tagged json
+			"""
+			[
+				{
+					"json": <text>
+				}
+			]
+			"""
+
 
 	@Other
 	Scenario: Some other scenario

--- a/gserver/test/data/features/before.format.feature
+++ b/gserver/test/data/features/before.format.feature
@@ -32,7 +32,7 @@ And here is the json
 
 And here is the tagged json
 """
-[{"json":<text>}]
+[{"<json>":<text>}]
 """
 
 

--- a/gserver/test/data/features/before.format.feature
+++ b/gserver/test/data/features/before.format.feature
@@ -30,6 +30,11 @@ And here is the json
 [{"json":"text"}]
 """
 
+And here is the tagged json
+"""
+[{"json":<text>}]
+"""
+
 
 @Other
 Scenario: Some other scenario


### PR DESCRIPTION
This should fix json formatting with scenario example <tags>

```json
[
	{
		"<json>": <text>
	}
]
```