### PR TITLE
fix: use cjkRegex to test cjk characters

### DIFF
--- a/gserver/src/format.ts
+++ b/gserver/src/format.ts
@@ -33,6 +33,9 @@ const FORMAT_CONF: FormatConf = {
     '@': 'relative',
 };
 
+const cjkRegex = /[\u3000-\u9fff\uac00-\ud7af\uff01-\uff60]/g;
+
+
 function findIndentation(line: string, settings: Settings): FormatConfVal | null {
     const format = findFormat(line, settings);
     return format ? format.value : null;
@@ -42,7 +45,7 @@ function findFormat(line: string, settings: Settings): ResolvedFormat | null {
     const settingsFormatConf = settings.cucumberautocomplete.formatConfOverride || {};
     const fnFormatFinder = (conf: FormatConf): ResolvedFormat | null => {
         const symbol = Object.keys(conf).find(key => !!~line.search(new RegExp(escapeRegExp('^\\s*' + key))));
-        return symbol ? {symbol, value: conf[symbol]} : null;
+        return symbol ? { symbol, value: conf[symbol] } : null;
     };
     const settingsFormat = fnFormatFinder(settingsFormatConf);
     const presetFormat = fnFormatFinder(FORMAT_CONF);
@@ -225,17 +228,8 @@ function createUUID() {
 }
 
 // Consider a CJK character is 2 spaces
-function stringBytesLen(c) {
-    let n = c.length, s;
-    let len = 0;
-    for (let i = 0; i < n; i++) {
-        s = c.charCodeAt(i);
-        while (s > 0) {
-            len++;
-            s = s >> 8;
-        }
-    }
-    return len;
+function stringBytesLen(str: string) {
+    return str.length + (str.match(cjkRegex) || []).length;
 }
 
 export function format(indent: string, text: string, settings: Settings): string {

--- a/gserver/test/data/features/after/general.feature
+++ b/gserver/test/data/features/after/general.feature
@@ -8,7 +8,7 @@ Feature: Formatting feature
 
 		Given the following users exist:
 			| name   | email              | twitter         | CJK Message 訊息    |
-			| Aslak  | aslak@cucumber.io  | @aslak_hellesoy | Yoo Hello world     |
+			| Aslak  | aslak@cucumber.io  | @aslak_hellesoy | ʏᴏᴏ Hello world     |
 			| Julien | julien@cucumber.io | @jbpros         | Yoo 你好 世界       |
 			| Matt   | matt@cucumber.io   | @mattwynne      | Yoo こんにちは 世界 |
 

--- a/gserver/test/data/features/before/general.feature
+++ b/gserver/test/data/features/before/general.feature
@@ -8,7 +8,7 @@ Background: Background name
 
 Given the following users exist:
 | name |email| twitter| CJK Message 訊息 |
-| Aslak|    aslak@cucumber.io | @aslak_hellesoy | Yoo Hello world |
+| Aslak|    aslak@cucumber.io | @aslak_hellesoy | ʏᴏᴏ Hello world |
 | Julien|julien@cucumber.io| @jbpros| Yoo 你好 世界 |
 | Matt|matt@cucumber.io| @mattwynne| Yoo こんにちは 世界 |
 


### PR DESCRIPTION
Using the same method [vscode-markdown](https://github.com/yzhang-gh/vscode-markdown/blob/master/src/tableFormatter.ts) does.

Should fix #328 