### PR TITLE
Fix formatting when using 'JSON' keyword

### DIFF
--- a/gclient/syntaxes/json-embed.json
+++ b/gclient/syntaxes/json-embed.json
@@ -5,7 +5,7 @@
   "patterns": [
     {
       "contentName": "meta.embedded.block.json",
-      "begin": "(json|JSON)\\s*$",
+      "begin": "(json|JSON)\\s*$\\v*\"\"\"",
       "end": "(?<=\"\"\")",
       "patterns": [
         {


### PR DESCRIPTION
This is related to #284 and #290 

I believe json embed should only be matched when `json` or `JSON` is at end of line AND `"""` is present on a next line.

I had the same formatting problems as mentioned in the related issues, but, as I don't use json embeds in my feature files, I am not sure to really understand the implications of this. Please review this change or give me indications on how to really test it.

As a side note, I would really like to see this fix asap because for now lack of coloring makes my feature files really hard to read.