### PR TITLE
fixed indentation of Doc Strings

### DIFF
--- a/gserver/src/format.ts
+++ b/gserver/src/format.ts
@@ -99,6 +99,8 @@ export function correctIndents(text, indent, settings: Settings) {
                 } else {
                     indentCount = defaultIndentation;
                 }
+
+                indentCount += (insideRule ? ruleIndentation : 0);
             }
             return line.replace(/^\s*/, indent.repeat(indentCount));
         })

--- a/gserver/test/data/features/after/rule.feature
+++ b/gserver/test/data/features/after/rule.feature
@@ -18,20 +18,24 @@ Feature: Highlander
 
 	Rule: Users are notified about overdue tasks on first use of the day
 
-	This text is
-	at the rule level
+		This text is
+		at the rule level
 
 		Background:
 
-		This text is
-		at the rule background level
+			This text is
+			at the rule background level
 
 			Given I have overdue tasks
+				"""
+				Task details
+				"""
 
+		@tag
 		Example: First use of the day
 
-		This text is
-		at the rule example level
+			This text is
+			at the rule example level
 
 			Given I last used the app yesterday
 			When I use the app
@@ -39,8 +43,8 @@ Feature: Highlander
 
 		Example: Already used today
 
-		This text is
-		also at the rule example level
+			This text is
+			also at the rule example level
 
 			Given I last used the app earlier today
 			When I use the app

--- a/gserver/test/data/features/before/rule.feature
+++ b/gserver/test/data/features/before/rule.feature
@@ -27,7 +27,11 @@ This text is
 at the rule background level
 
 Given I have overdue tasks
+"""
+Task details
+"""
 
+@tag
 Example: First use of the day
 
 This text is


### PR DESCRIPTION
Rule indentation was not being added to descriptions and "Doc Strings"

Format was not indenting correctly:
* rule descriptions
* scenario descriptions under a rule, or
* the content of `"""` doc strings.

Before change, formatted as:

```cucumber
Feature: Document Store
   Feature description.

   Scenario: One
      First scneario description.

      Given somthing

   Rule: Rule one
   Rule description.

      Scenario: Two
      Second scenario description.

         Given something
            """
         Some string.
            """
```

After this change is formatted as:

```cucumber
Feature: Document Store
   Feature description.

   Scenario: One
      First scneario description.

      Given somthing

   Rule: Rule one
      Rule description.

      Scenario: Two
         Second scenario description.

         Given something
            """
            Some string.
            """
```