### PR TITLE
Make table formatting handle pipes

### DIFF
--- a/gserver/src/format.ts
+++ b/gserver/src/format.ts
@@ -124,7 +124,7 @@ function formatTables(text) {
     //Get blocks with data in cucumber tables
     const blocks: Block[] = textArr
         .reduce((res, l, i, arr) => {
-            if (~l.search(/^\s*\|/)) {
+            if (~l.search(/^\s*\|.*\|/)) {
                 res.push({
                     line: i,
                     block: blockNum,


### PR DESCRIPTION
Problem:
- Table formatting was overly aggressive, formatting unnecessarily when there was just a single '|'

Solution:
- Change to require minimum of two '|' before formatting

#382