### PR TITLE
#378 fix relative indentation

### DIFF
--- a/gserver/src/format.ts
+++ b/gserver/src/format.ts
@@ -95,10 +95,10 @@ export function correctIndents(text, indent, settings: Settings) {
             } else {
                 // Actually we could use 'relative' type of formatting for both - relative and unknown strings
                 // In future this behaviour could be reviewed
-                const nextLine = textArr.slice(i + 1).find(l => typeof findIndentation(l, settings) === 'number');
-                if (nextLine) {
-                    const nextLineIndentation = findIndentation(nextLine, settings);
-                    indentCount = nextLineIndentation === null ? defaultIndentation : nextLineIndentation;
+                const previousLine = textArr.slice(i - 1).find(l => typeof findIndentation(l, settings) === 'number');
+                if (previousLine) {
+                    const previousLineIndentation = findIndentation(previousLine, settings);
+                    indentCount = previousLineIndentation === null ? defaultIndentation : previousLineIndentation;
                 } else {
                     indentCount = defaultIndentation;
                 }

--- a/gserver/test/data/features/after/general.feature
+++ b/gserver/test/data/features/after/general.feature
@@ -47,10 +47,10 @@ Feature: Formatting feature
 	@Other
 	Scenario: Some other scenario
 
-		When I do something
-		And do another thing
-		Then I should have a valid result
-			But not an invalid result
+			When I do something
+			And do another thing
+			Then I should have a valid result
+				But not an invalid result
 
 
 	Scenario: Should properly format star gherkin word
@@ -61,9 +61,10 @@ Feature: Formatting feature
 Scenario Outline: feeding a suckler cow
 
 		Given the cow weighs <weight> kg
-		When we calculate the feeding requirements
-		Then the energy should be <energy> MJ
-		And the protein should be <protein> kg
+		And the rabbit weighs <protein> kg
+			When we calculate the feeding requirements
+			Then the energy should be <energy> MJ
+			And the protein should be <protein> kg
 
 		Examples:
 			| weight | energy        | protein |

--- a/gserver/test/data/features/before/general.feature
+++ b/gserver/test/data/features/before/general.feature
@@ -53,6 +53,7 @@ Scenario: Should properly format star gherkin word
 Scenario Outline: feeding a suckler cow
 
 Given the cow weighs <weight> kg
+And the rabbit weighs <protein> kg
 When we calculate the feeding requirements
 Then the energy should be <energy> MJ
 And the protein should be <protein> kg

--- a/gserver/test/format.spec.ts
+++ b/gserver/test/format.spec.ts
@@ -6,8 +6,10 @@ const generalSettings = {
     cucumberautocomplete: {
         skipDocStringsFormat: true,
         formatConfOverride: {
-            'But': 3,
-            'And': 'asdasd',
+            'When': 3,
+            'Then': 3,
+            'But': 4,
+            'And': 'relative',
             'SomeTestKey': 12,
             'Scenario Outline': 0,
         }


### PR DESCRIPTION
Fix #378 

Before this fix :
```
		Given the cow weighs <weight> kg
		        And the rabbit weighs <protein> kg
			When we calculate the feeding requirements
			Then the energy should be <energy> MJ
	And the protein should be <protein> kg
```
Now, it's working : 
```
		Given the cow weighs <weight> kg
		And the rabbit weighs <protein> kg
			When we calculate the feeding requirements
			Then the energy should be <energy> MJ
			And the protein should be <protein> kg
```