### PR TITLE
Adding support for duplicates steps

### DIFF
--- a/gclient/package.json
+++ b/gclient/package.json
@@ -153,13 +153,13 @@
                     "default": false
                 },
                 "cucumberautocomplete.stepRegExSymbol": {
-                    "descrioption": "Provide step regex symbol. Ex. it would be \"'\" for When('I do something') definition",
+                    "description": "Provide step regex symbol. Ex. it would be \"'\" for When('I do something') definition",
                     "type": "string",
                     "required": false,
                     "default": false
                 },
                 "cucumberautocomplete.allowDuplicates": {
-                    "descrioption": "Allow duplicate step definitions for multiple context in same feature.",
+                    "description": "Allow duplicate step definitions for multiple context in same feature.",
                     "type": "boolean",
                     "required": false,
                     "default": false

--- a/gclient/package.json
+++ b/gclient/package.json
@@ -157,6 +157,12 @@
                     "type": "string",
                     "required": false,
                     "default": false
+                },
+                "cucumberautocomplete.allowDuplicates": {
+                    "descrioption": "Allow duplicate step definitions for multiple context in same feature.",
+                    "type": "boolean",
+                    "required": false,
+                    "default": false
                 }
             }
         }

--- a/gserver/src/typings.d.ts
+++ b/gserver/src/typings.d.ts
@@ -27,6 +27,7 @@ interface Settings {
         formatConfOverride?: FormatConf[],
         onTypeFormat?: boolean,
         gherkinDefinitionPart?: string,
-        stepRegExSymbol?: string
+        stepRegExSymbol?: string,
+        allowDuplicates?: boolean
     }
 }

--- a/gserver/test/steps.handler.spec.ts
+++ b/gserver/test/steps.handler.spec.ts
@@ -23,7 +23,7 @@ const settings = {
     }
 };
 
-const stepsDefinitionNum = 8;
+const stepsDefinitionNum = 7;
 
 const s = new StepsHandler(__dirname, settings);
 
@@ -191,7 +191,7 @@ describe('constructor', () => {
         expect(e[0]).to.have.property('count', 2);
         expect(e[1]).to.have.property('count', 1);
         expect(e[2]).to.have.property('count', 2);
-        expect(e[3]).to.have.property('count', 2);
+        expect(e[3]).to.have.property('count', 1);
     });
     it('should correcly fill all the step element fields', () => {
         const firstElement = e[0];
@@ -205,8 +205,8 @@ describe('constructor', () => {
         expect(firstElement.def['uri']).to.have.string('test.steps.js');
     });
     it('should set correct names to the invariants steps', () => {
-        expect(e[3]).to.have.property('text', 'I say a');
-        expect(e[4]).to.have.property('text', 'I say b');
+        expect(e[2]).to.have.property('text', 'I say a');
+        expect(e[3]).to.have.property('text', 'I say b');
     });
 });
 

--- a/gserver/test/steps.handler.spec.ts
+++ b/gserver/test/steps.handler.spec.ts
@@ -23,7 +23,7 @@ const settings = {
     }
 };
 
-const stepsDefinitionNum = 7;
+const stepsDefinitionNum = 8;
 
 const s = new StepsHandler(__dirname, settings);
 
@@ -191,7 +191,7 @@ describe('constructor', () => {
         expect(e[0]).to.have.property('count', 2);
         expect(e[1]).to.have.property('count', 1);
         expect(e[2]).to.have.property('count', 2);
-        expect(e[3]).to.have.property('count', 1);
+        expect(e[3]).to.have.property('count', 2);
     });
     it('should correcly fill all the step element fields', () => {
         const firstElement = e[0];
@@ -205,8 +205,8 @@ describe('constructor', () => {
         expect(firstElement.def['uri']).to.have.string('test.steps.js');
     });
     it('should set correct names to the invariants steps', () => {
-        expect(e[2]).to.have.property('text', 'I say a');
-        expect(e[3]).to.have.property('text', 'I say b');
+        expect(e[3]).to.have.property('text', 'I say a');
+        expect(e[4]).to.have.property('text', 'I say b');
     });
 });
 


### PR DESCRIPTION
Hello, I'm using webdriver.io with cucumber. I have the same scenarios for different platforms like Android and iOS. I can write one step definition for every scenario and I split functions by platforms with flags like `driver.isAndroid`. But I don't want this because it's not very convenient and optimal thus I duplicated my step definitions by below structure:

- steps
    - ios
        - definitions.js
    - android
        - definitions.js

In this structure, I need to see all duplicated definitions but I noticed I can't see them in VSCode also I can see all duplicated definitions in WebStorm. Then I made some changes. That's all.

![image](https://user-images.githubusercontent.com/11901620/142685018-682ccec8-58fb-48f7-9dad-1f20b7bcce4f.png)
