### PR TITLE
Update option text to account for spaces

### DIFF
--- a/gserver/src/steps.handler.ts
+++ b/gserver/src/steps.handler.ts
@@ -211,7 +211,7 @@ export default class StepsHandler {
         step = step.replace(/{}/g, '.*');
 
         //Optional Text
-        step = step.replace(/\(([a-z]+)\)/g, '($1)?');
+        step = step.replace(/\(([a-z ]+)\)/g, '($1)?');
 
         //Alternative text a/b/c === (a|b|c)
         step = step.replace(/([a-zA-Z]+)(?:\/([a-zA-Z]+))+/g, match => `(${match.replace(/\//g, '|')})`);


### PR DESCRIPTION
Hi, currently, the regex doesn't handle options that (have spaces) inside. I think this change should correct that? Thanks!