### PR TITLE
Feature/GitHub issue 393 arrow functions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,13 +2,6 @@
   "version": "0.1.0",
   "configurations": [
     {
-      "name": "Language Server",
-      "port": 9229,
-      "request": "attach",
-      "skipFiles": ["<node_internals>/**"],
-      "type": "pwa-node"
-    },
-    {
       "name": "Launch Extension",
       "type": "extensionHost",
       "request": "launch",
@@ -18,6 +11,29 @@
       "sourceMaps": true,
       "outFiles": ["${workspaceRoot}/gclient/out/src/**/*.js"],
       "preLaunchTask": "npm"
+    },
+    {
+      "name": "Language Server",
+      "port": 9229,
+      "request": "attach",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha Tests",
+      "cwd": "${workspaceRoot}/gserver",
+      "runtimeExecutable": "${workspaceRoot}/gserver/node_modules/.bin/mocha",
+      "windows": {
+        "runtimeExecutable": "${workspaceRoot}/gserver/node_modules/.bin/mocha.cmd"
+      },
+      "runtimeArgs": [
+        "-r",
+        "ts-node/register",
+        "${workspaceRoot}/gserver/test/**/*.spec.ts"
+      ],
+      "internalConsoleOptions": "openOnSessionStart"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
   "version": "0.1.0",
   "configurations": [
     {
-      "name": "Launch Extension",
+      "name": "Launch Extension + VSCode",
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
@@ -13,7 +13,7 @@
       "preLaunchTask": "npm"
     },
     {
-      "name": "Language Server",
+      "name": "Attach to Language Server",
       "port": 9229,
       "request": "attach",
       "skipFiles": ["<node_internals>/**"],
@@ -22,7 +22,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Mocha Tests",
+      "name": "Debug Server Tests",
       "cwd": "${workspaceRoot}/gserver",
       "runtimeExecutable": "${workspaceRoot}/gserver/node_modules/.bin/mocha",
       "windows": {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,16 +1,23 @@
 {
-	"version": "0.1.0",
-	"configurations": [
-		{
-			"name": "Launch Extension",
-			"type": "extensionHost",
-			"request": "launch",
-			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}/gclient" ],
-			"stopOnEntry": false,
-			"sourceMaps": true,
-			"outFiles": [ "${workspaceRoot}/gclient/out/src/**/*.js" ],
-			"preLaunchTask": "npm"
-		}
-	]
+  "version": "0.1.0",
+  "configurations": [
+    {
+      "name": "Language Server",
+      "port": 9229,
+      "request": "attach",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "pwa-node"
+    },
+    {
+      "name": "Launch Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": ["--extensionDevelopmentPath=${workspaceRoot}/gclient"],
+      "stopOnEntry": false,
+      "sourceMaps": true,
+      "outFiles": ["${workspaceRoot}/gclient/out/src/**/*.js"],
+      "preLaunchTask": "npm"
+    }
+  ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,20 +20,17 @@
       "type": "node"
     },
     {
-      "type": "node",
-      "request": "launch",
       "name": "Debug Server Tests",
-      "cwd": "${workspaceRoot}/gserver",
-      "runtimeExecutable": "${workspaceRoot}/gserver/node_modules/.bin/mocha",
-      "windows": {
-        "runtimeExecutable": "${workspaceRoot}/gserver/node_modules/.bin/mocha.cmd"
-      },
+      "request": "launch",
       "runtimeArgs": [
-        "-r",
-        "ts-node/register",
-        "${workspaceRoot}/gserver/test/**/*.spec.ts"
+        "run-script",
+        "test"
       ],
-      "internalConsoleOptions": "openOnSessionStart"
+      "runtimeExecutable": "npm",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "type": "node"
     }
   ]
 }

--- a/gserver/src/steps.handler.ts
+++ b/gserver/src/steps.handler.ts
@@ -124,10 +124,10 @@ export default class StepsHandler {
 
         // Step part getting
         const { stepRegExSymbol } = this.settings.cucumberautocomplete;
-        //Step text could be placed between '/' symbols (ex. in JS) or between quotes, like in Java
+        // Step text could be placed between '/' symbols (ex. in JS) or between quotes, like in Java
         const stepStart = stepRegExSymbol ? `(${stepRegExSymbol})` : `(\/|'|"|\`)`;
-        //Our step could contain any symbols, except of our 'stepStart'. Use \3 to be sure in this
-        //ref to RegEx Example: https://regex101.com/r/mS1zJ8/1
+        // ref to RegEx Example: https://regex101.com/r/mS1zJ8/1
+        // Use a RegEx that peeks ahead to ensure escape character can still work, like `\'`.
         const stepBody = stepRegExSymbol ? `([^${stepRegExSymbol}]+)` : `((?:(?=(?:\\\\)*)\\\\.|.)*?)`;
         //Step should be ended with same symbol it begins
         const stepEnd = stepRegExSymbol ? stepRegExSymbol : '\\3';

--- a/gserver/src/steps.handler.ts
+++ b/gserver/src/steps.handler.ts
@@ -128,7 +128,7 @@ export default class StepsHandler {
         const stepStart = stepRegExSymbol ? `(${stepRegExSymbol})` : `(\/|'|"|\`)`;
         // ref to RegEx Example: https://regex101.com/r/mS1zJ8/1
         // Use a RegEx that peeks ahead to ensure escape character can still work, like `\'`.
-        const stepBody = stepRegExSymbol ? `([^${stepRegExSymbol}]+)` : `((?:(?=(?:\\\\)*)\\\\.|.)*?)`;
+        const stepBody = `((?:(?=(?:\\\\)*)\\\\.|.)*?)`;
         //Step should be ended with same symbol it begins
         const stepEnd = stepRegExSymbol ? stepRegExSymbol : '\\3';
 

--- a/gserver/src/steps.handler.ts
+++ b/gserver/src/steps.handler.ts
@@ -127,7 +127,7 @@ export default class StepsHandler {
         //Step text could be placed between '/' symbols (ex. in JS) or between quotes, like in Java
         const stepStart = stepRegExSymbol ? `(${stepRegExSymbol})` : `(\/|'|"|\`)`;
         //Our step could contain any symbols, except of our 'stepStart'. Use \3 to be sure in this
-        const stepBody = stepRegExSymbol ? `([^${stepRegExSymbol}]+)` : '([^\\3]+)';
+        const stepBody = stepRegExSymbol ? `([^${stepRegExSymbol}]+)` : '([^\\3]*?)';
         //Step should be ended with same symbol it begins
         const stepEnd = stepRegExSymbol ? stepRegExSymbol : '\\3';
 

--- a/gserver/src/steps.handler.ts
+++ b/gserver/src/steps.handler.ts
@@ -127,7 +127,8 @@ export default class StepsHandler {
         //Step text could be placed between '/' symbols (ex. in JS) or between quotes, like in Java
         const stepStart = stepRegExSymbol ? `(${stepRegExSymbol})` : `(\/|'|"|\`)`;
         //Our step could contain any symbols, except of our 'stepStart'. Use \3 to be sure in this
-        const stepBody = stepRegExSymbol ? `([^${stepRegExSymbol}]+)` : '([^\\3]*?)';
+        //ref to RegEx Example: https://regex101.com/r/mS1zJ8/1
+        const stepBody = stepRegExSymbol ? `([^${stepRegExSymbol}]+)` : `((?:(?=(?:\\\\)*)\\\\.|.)*?)`;
         //Step should be ended with same symbol it begins
         const stepEnd = stepRegExSymbol ? stepRegExSymbol : '\\3';
 

--- a/gserver/test/data/steps/stepRegExSymbol.steps.js
+++ b/gserver/test/data/steps/stepRegExSymbol.steps.js
@@ -3,3 +3,12 @@ this.When(/I test back slashed step/)
 this.When('I test quotes step')
 
 this.When("I test double quotes step")
+
+// Non-standard strings tests
+// Used non-standard strings tests cases
+
+this.Given('I do "aa" something');
+this.When('I do \' something');
+    this.When('I do \' something different');
+this.Given('/^Me and "([^"]*)"$/');
+this.Given('the test cookie is set', () => cy.setCookie('TEST_COOKIE', 'true'));

--- a/gserver/test/steps.handler.spec.ts
+++ b/gserver/test/steps.handler.spec.ts
@@ -71,6 +71,7 @@ describe('geStepDefinitionMatch', () => {
         const nonStandardStrings = [
             [`Given(/I do "aa" something/);`, `I do "aa" something`],
             [String.raw`When('I do \' something');`, String.raw`I do \' something`], //String.raw needed to ensure escaped values can be read.
+            [`  When('I do something');`, `I do something`],
             [`"Given(/^Me and "([^"]*)"$/, function ()"`, `^Me and "([^"]*)"$`],
             [`Given('the test cookie is set', () => cy.setCookie('TEST_COOKIE', 'true'));`, `the test cookie is set`]
         ];

--- a/gserver/test/steps.handler.spec.ts
+++ b/gserver/test/steps.handler.spec.ts
@@ -436,8 +436,30 @@ describe('gherkin regex step start', () => {
     const customStepsHandler = new StepsHandler(__dirname, customSettings);
     const elements = customStepsHandler.getElements();
 
-    it('should correctly parse steps differs from stepRegExSymbol var', () => {
-        expect(elements.length).to.be.eq(1);
+    it('should correctly parse the default case', () => {
+        expect(elements.length).to.be.gte(1);
         expect(elements[0].text).to.be.eq('I test quotes step');
     });
+
+    it('should correctly parse non-standard string with ""', () => {
+        expect(elements.length).to.be.gte(2);
+        expect(elements[1].text).to.be.eq('I do "aa" something');
+    });
+    it('should correctly parse non-standard string an escape char', () => {
+        expect(elements.length).to.be.gte(3);
+        expect(elements[2].text).to.be.eq('I do \' something');
+    });
+    it('should correctly parse non-standard string a tab and escape char', () => {
+        expect(elements.length).to.be.gte(4);
+        expect(elements[3].text).to.be.eq('I do \' something different');
+    });
+    it('should correctly parse non-standard string a complex string', () => {
+        expect(elements.length).to.be.gte(5);
+        expect(elements[4].text).to.be.eq('/^Me and "([^"]*)"$/');
+    });
+    it('should correctly parse non-standard string with an arrow function', () => {
+        expect(elements.length).to.be.gte(6);
+        expect(elements[5].text).to.be.eq('the test cookie is set');
+    });
+    
 });

--- a/gserver/test/steps.handler.spec.ts
+++ b/gserver/test/steps.handler.spec.ts
@@ -70,14 +70,15 @@ describe('geStepDefinitionMatch', () => {
     describe('non-standard strings', () => {
         const nonStandardStrings = [
             [`Given(/I do "aa" something/);`, `I do "aa" something`],
-            [`When('I do \' something');`, `I do \' something`],
-            [`    When('I do something');`, `I do something`],
-            [`"Given(/^Me and "([^"]*)"$/, function ()"`, `^Me and "([^"]*)"$`]
+            [String.raw`When('I do \' something');`, String.raw`I do \' something`], //String.raw needed to ensure escaped values can be read.
+            [`"Given(/^Me and "([^"]*)"$/, function ()"`, `^Me and "([^"]*)"$`],
+            [`Given('the test cookie is set', () => cy.setCookie('TEST_COOKIE', 'true'));`, `the test cookie is set`]
         ];
         nonStandardStrings.forEach(str => {
             it(`should get "${str[1]}" step from "${str[0]}" string`, () => {
                 const match = s.geStepDefinitionMatch(str[0]);
-                expect(match).to.not.be.null;
+                expect(match).to.not.be.null;         
+                expect(match[4]).to.be.toString();   
                 expect(match[4]).to.be.equals(str[1]);
             });
         });

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "minor": "cd gserver && npm version minor --no-git-version && cd ../gclient && npm version minor --no-git-version",
     "server": "cd gserver && npm run watch",
     "compile": "cd gserver && npm run compile",
-    "publish": "cd gserver && npm run compile && npm run test && cd ../gclient && npm run publish"
+    "publish": "cd gserver && npm run compile && npm run test && cd ../gclient && npm run publish",
+    "test": "cd gserver && npm run test"
   }
 }


### PR DESCRIPTION
This PR added launch settings for the gServer so that can be debugged via VS Code. 

The primary change was to fix #393.

I changed to a more specific regex to support escape characters, also I updated the testing to ensure this works.

