### PR TITLE
Relative Indentation both ways

### DIFF
--- a/gclient/README.md
+++ b/gclient/README.md
@@ -80,7 +80,7 @@ It is allowing to handle some very specific case of page objects usage in the gh
 
 **`cucumberautocomplete.skipDocStringsFormat`** - Skip format of strings, that placed between ''' or \"\"\".
 
-**`cucumberautocomplete.formatConfOverride`** - Override some formatting via format conf strings = {[key: String]: num | 'relative'}, where key - beggining of the string, num - numeric value of indents or 'relative' (same to the previous line).
+**`cucumberautocomplete.formatConfOverride`** - Override some formatting via format conf strings = {[key: String]: num | 'relative' | 'relativeUp' }, where key - beggining of the string, num - numeric value of indents, 'relative' (same indent value as the next line), or 'relativeUp' (same as the previous line).
 Example:
 ```
 "cucumberautocomplete.formatConfOverride": {

--- a/gserver/src/format.ts
+++ b/gserver/src/format.ts
@@ -1,6 +1,6 @@
 import { escapeRegExp } from './util';
 
-type FormatConfVal = number | 'relative';
+type FormatConfVal = number | 'relative' | 'relativeUp' | 'relativeDown';
 
 interface FormatConf {
     [key: string]: FormatConfVal
@@ -93,12 +93,12 @@ export function correctIndents(text, indent, settings: Settings) {
             else if (format && typeof format.value === 'number') {
                 indentCount = format.value + (insideRule && format.symbol !== 'Rule:' ? ruleIndentation : 0);
             } else {
-                // Actually we could use 'relative' type of formatting for both - relative and unknown strings
-                // In future this behaviour could be reviewed
-                const nextLine = textArr.slice(i + 1).find(l => typeof findIndentation(l, settings) === 'number');
-                if (nextLine) {
-                    const nextLineIndentation = findIndentation(nextLine, settings);
-                    indentCount = nextLineIndentation === null ? defaultIndentation : nextLineIndentation;
+                const lookup = (format && format.value === 'relativeUp') ? textArr.slice(0, i).reverse() : textArr.slice(i + 1);
+                const relativeLine = lookup.find((l) => typeof findIndentation(l, settings) === 'number');
+                if (relativeLine) {
+                    if (format && format.symbol !== 'Rule:' && findFormat(relativeLine, settings).symbol === 'Rule:') { insideRule = false; }
+                    const relativeLineIndentation = findIndentation(relativeLine, settings);
+                    indentCount = relativeLineIndentation === null ? defaultIndentation : relativeLineIndentation;
                 } else {
                     indentCount = defaultIndentation;
                 }

--- a/gserver/src/format.ts
+++ b/gserver/src/format.ts
@@ -1,6 +1,6 @@
 import { escapeRegExp } from './util';
 
-type FormatConfVal = number | 'relative' | 'relativeUp' | 'relativeDown';
+type FormatConfVal = number | 'relative' | 'relativeUp';
 
 interface FormatConf {
     [key: string]: FormatConfVal


### PR DESCRIPTION
Fixed issues #343  and #378, which describe problems with relative indentation. According to the [README](https://github.com/alexkrechik/VSCucumberAutoComplete#all-the-settings-description), the 'relative' keyword should use the same indentation as the previous line. However, the code actually looks up lines _after_ the current line to determine the relative indentation. The PR adds the 'relativeUp' keyword to use indentation from previous lines. It also fixes an issue with multiple Rules in a single feature file, which resulted in wrong indentation for all but the first rule.

```
  "cucumberautocomplete.formatConfOverride": {
    "And": 3,
    "But": "relativeUp",
    "@": "relative"
  }
```

Result before this PR (notice the `But` and the last `@tag` not being indented correctly):
```
@tag
Feature: Some Feature

  @tag
  Rule: Some rule
    Some description

    @tag
    Scenario:
      Some description
      Given Start to type your Given step here
        And something else
      But something different
      When Start to type your When step here
      Then Start to type your Then step here

    @tag
  Rule: Some rule
    Some description
```

Result with this PR:

```
@tag
Feature: Some Feature

  @tag
  Rule: Some rule
    Some description

    @tag
    Scenario:
      Some description
      Given Start to type your Given step here
        And something else
        But something different
      When Start to type your When step here
      Then Start to type your Then step here

  @tag
  Rule: Some rule
    Some description
 ```