### PR TITLE
fix: add correct regex for {word} per Cucumber standard

### DIFF
--- a/gserver/src/steps.handler.ts
+++ b/gserver/src/steps.handler.ts
@@ -209,7 +209,7 @@ export default class StepsHandler {
         step = step.replace(/{float}/g, '-?\\d*\\.?\\d+');
         step = step.replace(/{int}/g, '-?\\d+');
         step = step.replace(/{stringInDoubleQuotes}/g, '"[^"]+"');
-        step = step.replace(/{word}/g, '[A-Za-z]+');
+        step = step.replace(/{word}/g, '[^\\s]+');
         step = step.replace(/{string}/g, '(\"|\')[^\\1]*\\1');
         step = step.replace(/{}/g, '.*');
 


### PR DESCRIPTION
Fixed so steps.handler.ts follows Cucumber's regex for {word}.

Currently the extension uses '[A-Za-z]+' while Cucumber uses '[^\s]+' per their [documentation](https://cucumber.github.io/try-cucumber-expressions/?expression=&step=&advanced=1) and their [code](https://github.com/cucumber/cucumber-expressions/blob/c8a1fccffe6d30afad496319fce0b8de21aae8a1/javascript/src/defineDefaultParameterTypes.ts#L6)