### PR TITLE
fix[ClearComments]: add python comments handling

### DIFF
--- a/gserver/src/steps.handler.ts
+++ b/gserver/src/steps.handler.ts
@@ -17,6 +17,7 @@ import {
     getOSPath,
     getFileContent,
     clearComments,
+    clearPythonComments,
     getMD5Id,
     escapeRegExp,
     escaprRegExpForPureText,
@@ -527,7 +528,7 @@ export default class StepsHandler {
     getFileSteps(filePath: string) {
         const fileContent = getFileContent(filePath);
         const fileComments = this.getMultiLineComments(fileContent);
-        const definitionFile = clearComments(fileContent);
+        const definitionFile = filePath.endsWith('.py') ? clearPythonComments(fileContent) : clearComments(fileContent);
         return definitionFile
             .split(/\r?\n/g)
             .reduce((steps, line, lineIndex, lines) => {
@@ -559,9 +560,11 @@ export default class StepsHandler {
                         getOSPath(filePath),
                         Range.create(pos, pos)
                     );
-                    steps = steps.concat(
-                        this.getSteps(finalLine, stepPart, def, gherkin, fileComments)
-                    );
+                    if(stepPart != '') {
+                        steps = steps.concat(
+                            this.getSteps(finalLine, stepPart, def, gherkin, fileComments)
+                        );
+                    }
                 }
                 return steps;
             }, new Array<Step>());

--- a/gserver/src/util.ts
+++ b/gserver/src/util.ts
@@ -38,6 +38,69 @@ export function clearGherkinComments(text: string): string {
     return strip(text, { preserveNewlines: true });
 }
 
+
+export function clearPythonComments(text: string): string {
+    // Clear all single and multiline comments
+    let commentsMode: 'none' | 'singleTriplet' | 'doubleTriplet' = 'none';
+    text = text.split(/\r?\n/g).map(l => {
+            switch (commentsMode) {
+                case 'singleTriplet': {
+                    const match = l.match(/^.*(''')/);
+                    if (match) {
+                        commentsMode = 'none';
+                        const offset = match[0].length - match[1].length;
+                        return ' '.repeat(offset) + l.substring(offset);
+                    }
+                }
+                    break;
+
+                case 'doubleTriplet': {
+                    const match = l.match(/^.*(""")/);
+                    if (match) {
+                        commentsMode = 'none';
+                        const offset = match[0].length - match[1].length;
+                        return ' '.repeat(offset) + l.substring(offset);
+                    }
+                }
+                    break;
+
+                case 'none':
+                default: {
+                    const match = l.match(/^.*f?("""|''')/);
+                    if (match) {
+                        if (match[1] === "'''") {
+                            commentsMode = 'singleTriplet';
+                        } else if (match[1] === '"""') {
+                            commentsMode = 'doubleTriplet';
+                        }
+
+                        // Check if it's a single-line triple-quote comment
+                        const closingTripleQuote = l.match(/(''')|(""")/g);
+                        if (closingTripleQuote && closingTripleQuote.length === 2) {
+                            commentsMode = 'none';
+                            return '';
+                        }
+
+                        // Strip the content after the match
+                        return l.substring(0, match[0].length);
+                    }
+                }
+                    return l;
+            }
+        })
+        .join('\r\n');
+
+    // Clear all line comments
+    text = text
+        .split(/\r?\n/g)
+        .map(l => {
+            return l.replace(/#.*$/gm, '');
+        })
+        .join('\r\n');
+
+    return text;
+}
+
 export function getMD5Id(str: string): string {
     return md5(str);
 }


### PR DESCRIPTION
Added functionality to remove Python comments from text to fix errors where steps couldn't be found because docstrings were used.