### PR TITLE
fix regexp support in customParameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ This option could speed up new steps adding up to several times. Try it ;)
 
 **`cucumberautocomplete.stepsInvariants`** - Show all the 'or' steps parts as separate suggestions (ex. show `I use a` and `I use b` steps suggestions for the `Given(/I use (a|b)/)` step. It also could help to speed up the new steps adding.
 
-**`cucumberautocomplete.customParameters`** - Change some steps RegEx parts depending on array of 'parameter' - 'value' key pairs. Parameter could be string or RegEx object.
+**`cucumberautocomplete.customParameters`** - Change some steps RegEx parts depending on array of 'parameter' - 'value' key pairs. Parameter could be string or regular expression. Whether 'parameter' is interpreted as a string or a regular expression is 
+controlled by 'isRegexp' option.
 This setting will be applied before the steps getting.
 For ex. to get step from the py expression `@given(u'I do something')` we could use the next parameters:
 ```
@@ -148,8 +149,9 @@ By default, all the `' ' "` symbols will be used do define start and the end of 
             "value":"(a|b)"
         },
         {
-            "parameter":/\{a.*\}/,
-            "value":"a"
+            "parameter":"\\{a.*\\}",
+            "value":"a",
+            "isRegexp": true
         },
     ],
     "cucumberautocomplete.pages": {

--- a/gserver/src/steps.handler.ts
+++ b/gserver/src/steps.handler.ts
@@ -206,8 +206,17 @@ export default class StepsHandler {
             return step;
         }
         customParameters.forEach((p: CustomParameter) => {
-            const { parameter, value } = p;
-            step = step.split(parameter).join(value);
+            const { parameter, value, isRegexp } = p;
+
+            if (isRegexp) {
+                try {
+                    step = step.split(new RegExp(parameter)).join(value);
+                } catch {
+                    return;
+                }
+            } else {
+                step = step.split(parameter).join(value);
+            }
         });
         return step;
     }

--- a/gserver/src/types.ts
+++ b/gserver/src/types.ts
@@ -5,8 +5,9 @@ export type PagesSettings = {
 };
 
 export type CustomParameter = {
-    parameter: string | RegExp,
-    value: string
+    parameter: string,
+    value: string,
+    isRegexp?: boolean
 };
 
 type FormatConfVal = number | 'relative' | 'relativeUp';

--- a/gserver/test/steps.handler.spec.ts
+++ b/gserver/test/steps.handler.spec.ts
@@ -15,8 +15,9 @@ const settings = {
       value: '([a-zA-Z0-9_-]+ dictionary|"[^"]*")',
     },
     {
-      parameter: /\{a.*\}/,
+      parameter: "\\{a.*\\}",
       value: 'aa',
+      isRegexp: true,
     },
   ],
 };


### PR DESCRIPTION
Fixes https://github.com/alexkrechik/VSCucumberAutoComplete/issues/411 and provides w/a for https://github.com/alexkrechik/VSCucumberAutoComplete/issues/462.

Currently `step.handlers` expect that `customParameters.parameter` can contain a RegExp object, but `settings.json` is a plain json file, so that's not possible to achieve.

This MR introduces `isRegexp` field in `CustomParameter` - a boolean, which controls whether  `parameter` will be interpreted as a plain string or a regular expression. `isRegexp` is optional and when it's not specified, `parameter` will be interpreted as a plain string, ensuring backward compatibility (existing user settings will keep working as before).