### PR TITLE
feat: add support for parsing multiline step definitions

### DIFF
--- a/gserver/src/steps.handler.ts
+++ b/gserver/src/steps.handler.ts
@@ -111,18 +111,24 @@ export default class StepsHandler {
         return this.elemenstCountHash[id] || 0;
     }
 
-    getStepRegExp() {
-    //Actually, we dont care what the symbols are before our 'Gherkin' word
-    //But they shouldn't end with letter
+    getStepPrefix() {
+        //Actually, we dont care what the symbols are before our 'Gherkin' word
+        //But they shouldn't end with letter
         const startPart = "^((?:[^'\"/]*?[^\\w])|.{0})";
 
         //All the steps should be declared using any gherkin keyword. We should get first 'gherkin' word
         const gherkinPart =
-      this.settings.gherkinDefinitionPart ||
-      `(${allGherkinWords}|defineStep|Step|StepDefinition)`;
+            this.settings.gherkinDefinitionPart ||
+            `(${allGherkinWords}|defineStep|Step|StepDefinition)`;
 
         //All the symbols, except of symbols, using as step start and letters, could be between gherkin word and our step
         const nonStepStartSymbols = '[^/\'"`\\w]*?';
+
+        return startPart + gherkinPart + nonStepStartSymbols;
+    }
+
+    getStepRegExp() {
+        const stepPrefix = this.getStepPrefix();
 
         // Step part getting
         const { stepRegExSymbol } = this.settings;
@@ -136,12 +142,10 @@ export default class StepsHandler {
 
         //Our RegExp will be case-insensitive to support cases like TypeScript (...@when...)
         const r = new RegExp(
-            startPart +
-        gherkinPart +
-        nonStepStartSymbols +
-        stepStart +
-        stepBody +
-        stepEnd,
+            stepPrefix +
+            stepStart +
+            stepBody +
+            stepEnd,
             'i'
         );
 
@@ -149,8 +153,17 @@ export default class StepsHandler {
         return r;
     }
 
-    geStepDefinitionMatch(line: string) {
+
+    getStepPrefixRegExp() {
+        return new RegExp(this.getStepPrefix(), 'i');
+    }
+
+    getStepDefinitionMatch(line: string) {
         return line.match(this.getStepRegExp());
+    }
+
+    getStepPrefixMatch(line: string) {
+        return line.match(this.getStepPrefixRegExp());
     }
 
     getOutlineVars(text: string) {
@@ -541,26 +554,7 @@ export default class StepsHandler {
         return definitionFile
             .split(/\r?\n/g)
             .reduce((steps, line, lineIndex, lines) => {
-                //TODO optimize
-                let match;
-                let finalLine = '';
-                const currLine = this.handleCustomParameters(line);
-                const currentMatch = this.geStepDefinitionMatch(currLine);
-                //Add next line to our string to handle two-lines step definitions
-                const nextLine = this.handleCustomParameters(lines[lineIndex + 1] || '');
-                if (currentMatch) {
-                    match = currentMatch;
-                    finalLine = currLine;
-                } else if (nextLine) {
-                    const nextLineMatch = this.geStepDefinitionMatch(nextLine);
-                    const bothLinesMatch = this.geStepDefinitionMatch(
-                        currLine + nextLine
-                    );
-                    if (bothLinesMatch && !nextLineMatch) {
-                        match = bothLinesMatch;
-                        finalLine = currLine + nextLine;
-                    }
-                }
+                const { match, finalLine } = this.getStepDefinition(line, lineIndex, lines);
                 if (match) {
                     const [, beforeGherkin, gherkinString, , stepPart] = match;
                     const gherkin = getGherkinTypeLower(gherkinString);
@@ -749,5 +743,32 @@ export default class StepsHandler {
     getCompletionResolve(item: CompletionItem) {
         this.incrementElementCount(item.data);
         return item;
+    }
+
+    getStepDefinition(line: string, lineIndex: number, lines: string[]) {
+        //TODO optimize
+        let match: RegExpMatchArray | null = null;
+        let finalLine = '';
+        const currLine = this.handleCustomParameters(line);
+        const currentMatch = this.getStepDefinitionMatch(currLine);
+        if (currentMatch) {
+            match = currentMatch;
+            finalLine = currLine;
+        } else {
+            // Look for a multi-line step definition
+            const currentPrefixMatch = this.getStepPrefixMatch(line);
+            if (currentPrefixMatch) {
+                // This line is the start of a step definition
+                finalLine = line.trim();
+                for (let i = lineIndex + 1; i < lines.length && !match; i++) {
+                    finalLine += lines[i].trim();
+
+                    // Check if the combined lines now match a step definition
+                    match = this.getStepDefinitionMatch(this.handleCustomParameters(finalLine));
+                }
+            }
+        }
+
+        return { match, finalLine };
     }
 }

--- a/gserver/test/steps.handler.spec.ts
+++ b/gserver/test/steps.handler.spec.ts
@@ -39,7 +39,7 @@ const stepsDefinitionNum = 7;
 
 const s = new StepsHandler(__dirname, settings);
 
-describe('geStepDefinitionMatch', () => {
+describe('getStepDefinitionMatch', () => {
   describe('gherkin strings types', () => {
     const strings = [
       'Given(/I do something/, function(){);',
@@ -51,7 +51,7 @@ describe('geStepDefinitionMatch', () => {
     ];
     strings.forEach((str) => {
       it(`should parse "${str}" step string`, () => {
-        const match = s.geStepDefinitionMatch(str);
+        const match = s.getStepDefinitionMatch(str);
         expect(match).not.toBeNull();
         expect(match![4]).toStrictEqual('I do something');
       });
@@ -72,7 +72,7 @@ describe('geStepDefinitionMatch', () => {
     ];
     gherkinWords.forEach((g) => {
       it(`should parse "${g}(/I do something/" string with ${g} gherkin word`, () => {
-        const match = s.geStepDefinitionMatch(
+        const match = s.getStepDefinitionMatch(
           `${g}(/I do something/, function(){);`
         );
         expect(match).not.toBeNull();
@@ -94,7 +94,7 @@ describe('geStepDefinitionMatch', () => {
     ];
     nonStandardStrings.forEach((str) => {
       it(`should get "${str[1]}" step from "${str[0]}" string`, () => {
-        const match = s.geStepDefinitionMatch(str[0]);
+        const match = s.getStepDefinitionMatch(str[0]);
         expect(match).not.toBeNull();
         expect(match![4]).toStrictEqual(str[1]);
       });
@@ -109,7 +109,7 @@ describe('geStepDefinitionMatch', () => {
     ];
     inbvalidStrings.forEach((str) => {
       it(`should not parse "${str}" string`, () => {
-        const match = s.geStepDefinitionMatch(str);
+        const match = s.getStepDefinitionMatch(str);
         expect(match).toBeNull();
       });
     });
@@ -119,7 +119,26 @@ describe('geStepDefinitionMatch', () => {
     const line =
       'Then(/^I do Fast Sign in with "([^"]*)" and "([^"]*)"$/)do |email, pwd|';
     const match = '^I do Fast Sign in with "([^"]*)" and "([^"]*)"$';
-    expect(s.geStepDefinitionMatch(line)![4]).toStrictEqual(match);
+    expect(s.getStepDefinitionMatch(line)![4]).toStrictEqual(match);
+  });
+});
+
+describe('getStepDefinition', () => {
+  it('should handle a multi-line step definition', () => {
+    const lines = [
+      '@then(',
+      '    "I do something for the column \'{first_column}\' "',
+      '    "and the column \'{second_column}\'"',
+      ')'
+    ];
+    const { match } = s.getStepDefinition(lines[0], 0, lines);
+    expect(match).not.toBeNull();
+  });
+
+  it('should not not match when a step definition is not complete', () => {
+    const line = '@then(';
+    const { match } = s.getStepDefinition(line, 0, [line]);
+    expect(match).toBeNull();
   });
 });
 


### PR DESCRIPTION
This would address issue #532 by supporting step definitions that are wrapped across multiple lines. This also fixes a typo: `geStepDefinitionMatch` should be `getStepDefinitionMatch`.